### PR TITLE
Perform error checking first

### DIFF
--- a/source/helpers/focus-visible.scss
+++ b/source/helpers/focus-visible.scss
@@ -1,15 +1,20 @@
 // FOCUS VISIBLE
 // -----------------------------------------------------------------------------
 
+@use "sass:list";
 @use "../settings" as *;
 
 @mixin focus-visible($style: "contour") {
+  $valid-styles: ("contour", "rounded");
+
+  @if list.index($valid-styles, $style) == null {
+    @error "Invalid visible focus style name. Check spelling or review helper definition.";
+  }
+
   outline: 2px solid $color-focal-medium;
   outline-offset: 2px;
 
   @if $style == "rounded" {
     border-radius: $border-radius-small;
-  } @else if $style != "contour" {
-    @error "Invalid visible focus style name. Check spelling or review helper definition.";
   }
 }

--- a/source/helpers/focus-visible.scss
+++ b/source/helpers/focus-visible.scss
@@ -8,7 +8,7 @@
   $valid-styles: ("contour", "rounded");
 
   @if list.index($valid-styles, $style) == null {
-    @error "Invalid visible focus style name. Check spelling or review helper definition.";
+    @error "Invalid visible focus style. Check spelling or review helper definition.";
   }
 
   outline: 2px solid $color-focal-medium;

--- a/source/helpers/set-breakpoint.scss
+++ b/source/helpers/set-breakpoint.scss
@@ -5,13 +5,15 @@
 @use "../settings" as *;
 
 @mixin set-breakpoint($name) {
+  @if ($name != "small" and map.has-key($breakpoints, $name) == false) {
+    @error "Invalid breakpoint name. Check spelling or review viewport breakpoint settings.";
+  }
+
   @if ($name == "small") {
     @content;
-  } @else if map.has-key($breakpoints, $name) {
+  } @else {
     @media screen and (min-width: map.get($breakpoints, $name)) {
       @content;
     }
-  } @else {
-    @error "Invalid breakpoint name. Check spelling or review viewport breakpoint settings.";
   }
 }


### PR DESCRIPTION
Error checking should be carried out right from the start in order to avoid unnecessarily parsing code and to establish a more straightforward module architecture.