### PR TITLE
Rename phasing management helper parameter

### DIFF
--- a/source/helpers/manage-phasing.js
+++ b/source/helpers/manage-phasing.js
@@ -5,18 +5,18 @@ const CLASS_PHASING_IN = "is-phasing-in";
 const CLASS_PHASING_OUT = "is-phasing-out";
 const CLASS_SHOWN = "is-shown";
 
-function managePhasing(...items) {
-  items.forEach((item) => {
-    const isShown = item.classList.contains(CLASS_SHOWN);
+function managePhasing(...elements) {
+  elements.forEach((element) => {
+    const isShown = element.classList.contains(CLASS_SHOWN);
     const phasingClass = isShown ? CLASS_PHASING_OUT : CLASS_PHASING_IN;
 
-    item.classList.add(phasingClass);
+    element.classList.add(phasingClass);
 
-    item.addEventListener(
+    element.addEventListener(
       "animationend",
       () => {
-        item.classList.remove(phasingClass);
-        item.classList.toggle(CLASS_SHOWN);
+        element.classList.remove(phasingClass);
+        element.classList.toggle(CLASS_SHOWN);
       },
       { once: true }
     );


### PR DESCRIPTION
The term "element" should be used to designate non-specific HTML nodes.