### PR TITLE
Add luminance evaluation tool

### DIFF
--- a/source/settings/color.scss
+++ b/source/settings/color.scss
@@ -62,3 +62,9 @@ $color-white-transparent-900: hsl(0, 0%, 100%, 0.92);
 // Black
 
 $color-black-transparent-700: hsl(0, 0%, 0%, 0.72);
+
+@use "../tools/compute-luminance" as *;
+
+$luminance: compute-luminance($color-brand-100);
+
+@debug ("Color luminance is #{$luminance}");

--- a/source/settings/color.scss
+++ b/source/settings/color.scss
@@ -62,9 +62,3 @@ $color-white-transparent-900: hsl(0, 0%, 100%, 0.92);
 // Black
 
 $color-black-transparent-700: hsl(0, 0%, 0%, 0.72);
-
-@use "../tools/compute-luminance" as *;
-
-$luminance: compute-luminance($color-brand-100);
-
-@debug ("Color luminance is #{$luminance}");

--- a/source/tools/compute-luminance.scss
+++ b/source/tools/compute-luminance.scss
@@ -4,13 +4,13 @@
 @use "sass:math";
 
 @function compute-luminance($color) {
-  $colors: (
+  $channels: (
     "red": red($color),
     "green": green($color),
     "blue": blue($color),
   );
 
-  @each $name, $value in $colors {
+  @each $name, $value in $channels {
     $value: math.div($value, 255);
 
     @if $value < 0.03928 {
@@ -20,13 +20,13 @@
       $value: math.pow($value, 2.4);
     }
 
-    $colors: map-merge(
-      $colors,
+    $channels: map-merge(
+      $channels,
       (
         $name: $value,
       )
     );
   }
 
-  @return (map-get($colors, "red") * 0.2126) + (map-get($colors, "green") * 0.7152) + (map-get($colors, "blue") * 0.0722);
+  @return (map-get($channels, "red") * 0.2126) + (map-get($channels, "green") * 0.7152) + (map-get($channels, "blue") * 0.0722);
 }

--- a/source/tools/compute-luminance.scss
+++ b/source/tools/compute-luminance.scss
@@ -1,0 +1,32 @@
+// COMPUTE LUMINANCE
+// -----------------------------------------------------------------------------
+
+@use "sass:math";
+
+@function compute-luminance($color) {
+  $colors: (
+    "red": red($color),
+    "green": green($color),
+    "blue": blue($color),
+  );
+
+  @each $name, $value in $colors {
+    $value: math.div($value, 255);
+
+    @if $value < 0.03928 {
+      $value: math.div($value, 12.92);
+    } @else {
+      $value: math.div(($value + 0.055), 1.055);
+      $value: math.pow($value, 2.4);
+    }
+
+    $colors: map-merge(
+      $colors,
+      (
+        $name: $value,
+      )
+    );
+  }
+
+  @return (map-get($colors, "red") * 0.2126) + (map-get($colors, "green") * 0.7152) + (map-get($colors, "blue") * 0.0722);
+}


### PR DESCRIPTION
Knowing the luminance of a color is useful when trying to establish a perceptually uniform color palette. Various websites can help with this task, but providing a dedicated tool guarantees availability at any time.