### PR TITLE
Remove unnecessary border width setting

### DIFF
--- a/source/settings/decoration.scss
+++ b/source/settings/decoration.scss
@@ -9,7 +9,6 @@ $opacity-500: 0.5;
 
 $border-width-1: 1px;
 $border-width-2: 2px;
-$border-width-4: 4px;
 
 // Border radius
 


### PR DESCRIPTION
Horizontal rule height is hard coded and no longer defined with the aid of a border width variable.