### PR TITLE
Change visible focus radius default value

### DIFF
--- a/source/helpers/focus-visible.scss
+++ b/source/helpers/focus-visible.scss
@@ -4,8 +4,8 @@
 @use "sass:list";
 @use "../settings" as *;
 
-@mixin focus-visible($radius: "radius-o") {
-  $valid-radii: ("radius-1", "radius-4", "radius-o");
+@mixin focus-visible($radius: null) {
+  $valid-radii: ("radius-1", "radius-4", null);
 
   @if (list.index($valid-radii, $radius) == null) {
     @error "Invalid visible focus radius. Check spelling or review helper definition.";


### PR DESCRIPTION
Best use `null` as the default radius value in order to clearly indicate that no explicit corner rounding occurs.