### PR TITLE
Define small viewport breakpoint

### DIFF
--- a/source/helpers/set-breakpoint.scss
+++ b/source/helpers/set-breakpoint.scss
@@ -5,7 +5,7 @@
 @use "../settings" as *;
 
 @mixin set-breakpoint($name) {
-  @if ($name != "sm" and map.has-key($breakpoints, $name) == false) {
+  @if (map.has-key($breakpoints, $name) == false) {
     @error "Invalid breakpoint name. Check spelling or review viewport breakpoint settings.";
   }
 

--- a/source/settings/viewport.scss
+++ b/source/settings/viewport.scss
@@ -4,6 +4,7 @@
 // Breakpoints
 
 $breakpoints: (
+  "sm": 0,
   "md": 720px,
   "lg": 1080px,
 );


### PR DESCRIPTION
The "sm" breakpoint designation aids with grid layout set up so it should be explicitly defined even if the corresponding value is not employed.