### PR TITLE
Rename repeating decimal variables

### DIFF
--- a/source/components/accordion/accordion.scss
+++ b/source/components/accordion/accordion.scss
@@ -21,7 +21,7 @@
     border: 0;
     margin-top: -$border-width-1;
     font-size: $font-size-1-125;
-    line-height: $line-height-1-333;
+    line-height: $line-height-1-3333;
     color: $color-neutral-050;
     background-color: transparent;
     transition: color $transition-ease-out-100, outline $transition-ease-out-100;

--- a/source/components/card/card.scss
+++ b/source/components/card/card.scss
@@ -41,6 +41,6 @@
 
   &-heading {
     font-size: $font-size-1-3125;
-    line-height: $line-height-1-333;
+    line-height: $line-height-1-3333;
   }
 }

--- a/source/components/dialog/dialog.scss
+++ b/source/components/dialog/dialog.scss
@@ -37,7 +37,7 @@
 
   &-heading {
     font-size: $font-size-1-5;
-    line-height: $line-height-1-333;
+    line-height: $line-height-1-3333;
   }
 
   &-action-group {

--- a/source/components/global-header/global-header.scss
+++ b/source/components/global-header/global-header.scss
@@ -23,7 +23,7 @@
     padding-bottom: $space-0-375;
     margin-right: $space-2;
     font-size: $font-size-1-5;
-    line-height: $line-height-1-333;
+    line-height: $line-height-1-3333;
     font-weight: $font-weight-700;
     color: $color-neutral-050;
     transition: color $transition-ease-out-100, outline $transition-ease-out-100;

--- a/source/components/notice/notice.scss
+++ b/source/components/notice/notice.scss
@@ -12,6 +12,6 @@
   &-heading {
     margin-bottom: $space-0-5;
     font-size: $font-size-1-125;
-    line-height: $line-height-1-333;
+    line-height: $line-height-1-3333;
   }
 }

--- a/source/reset.scss
+++ b/source/reset.scss
@@ -97,7 +97,7 @@ h6 {
 
 h1 {
   font-size: $font-size-3;
-  line-height: $line-height-1-166;
+  line-height: $line-height-1-1666;
 }
 
 h2 {
@@ -107,17 +107,17 @@ h2 {
 
 h3 {
   font-size: $font-size-1-5;
-  line-height: $line-height-1-333;
+  line-height: $line-height-1-3333;
 }
 
 h4 {
   font-size: $font-size-1-3125;
-  line-height: $line-height-1-333;
+  line-height: $line-height-1-3333;
 }
 
 h5 {
   font-size: $font-size-1-125;
-  line-height: $line-height-1-333;
+  line-height: $line-height-1-3333;
 }
 
 h6 {

--- a/source/settings/typography.scss
+++ b/source/settings/typography.scss
@@ -18,9 +18,9 @@ $font-size-3: 3rem;
 
 // Line height
 
-$line-height-1-166: 1.16666666;
+$line-height-1-1666: 1.16666666;
 $line-height-1-25: 1.25;
-$line-height-1-333: 1.33333333;
+$line-height-1-3333: 1.33333333;
 $line-height-1-5: 1.5;
 
 // Font weight


### PR DESCRIPTION
Use four digits to designate repeating decimal values in order to provide unambiguous variable names.