### PR TITLE
Rephrase breakpoint setting helper error message

### DIFF
--- a/source/helpers/set-breakpoint.scss
+++ b/source/helpers/set-breakpoint.scss
@@ -6,7 +6,7 @@
 
 @mixin set-breakpoint($name) {
   @if (map.has-key($breakpoints, $name) == false) {
-    @error "Invalid breakpoint name. Check spelling or review viewport breakpoint settings.";
+    @error "Invalid breakpoint name. Check spelling or review viewport breakpoints setting.";
   }
 
   @if ($name == "sm") {


### PR DESCRIPTION
Error messages should be clear and easy to understand.