### PR TITLE
Simplify Sass conditional statements

### DIFF
--- a/source/helpers/set-breakpoint.scss
+++ b/source/helpers/set-breakpoint.scss
@@ -5,11 +5,11 @@
 @use "../tokens" as *;
 
 @mixin set-breakpoint($name) {
-  @if (map.has-key($breakpoints, $name) == false) {
+  @if not map.has-key($breakpoints, $name) {
     @error "Invalid breakpoint name. Check spelling or review viewport breakpoints setting.";
   }
 
-  @if ($name == "sm") {
+  @if $name == "sm" {
     @content;
   } @else {
     @media screen and (min-width: map.get($breakpoints, $name)) {

--- a/source/helpers/style-focus.scss
+++ b/source/helpers/style-focus.scss
@@ -7,16 +7,16 @@
 @mixin style-focus($radius: null) {
   $valid-radii: ("radius-1", "radius-4", null);
 
-  @if (list.index($valid-radii, $radius) == null) {
+  @if not list.index($valid-radii, $radius) {
     @error "Invalid focus radius. Check spelling or review helper definition.";
   }
 
   outline: 2px solid $color-brand-100;
   outline-offset: 2px;
 
-  @if ($radius == "radius-1") {
+  @if $radius == "radius-1" {
     border-radius: $border-radius-1;
-  } @else if ($radius == "radius-4") {
+  } @else if $radius == "radius-4" {
     border-radius: $border-radius-4;
   }
 }


### PR DESCRIPTION
Brackets are optional when defining conditional statements and omitting them leads to code that is easier to read.