### PR TITLE
Rephrase breakpoint helper error message

### DIFF
--- a/source/helpers/set-breakpoint.scss
+++ b/source/helpers/set-breakpoint.scss
@@ -6,7 +6,7 @@
 
 @mixin set-breakpoint($name) {
   @if not map.has-key($breakpoints, $name) {
-    @error "Invalid breakpoint name. Check spelling or review viewport breakpoints setting.";
+    @error "Invalid breakpoint name. Check spelling or review viewport breakpoint tokens.";
   }
 
   @if $name == "sm" {


### PR DESCRIPTION
Use "tokens" instead of "settings" to designate global style values.