### PR TITLE
Rename component initialization helper definition parameter

### DIFF
--- a/source/helpers/initialize-component.js
+++ b/source/helpers/initialize-component.js
@@ -1,10 +1,10 @@
 // INITIALIZE COMPONENT
 // -----------------------------------------------------------------------------
 
-function initializeComponent(component, selector) {
+function initializeComponent(definition, selector) {
   const elements = Array.from(document.querySelectorAll(selector));
 
-  elements.forEach((element) => component(element));
+  elements.forEach((element) => definition(element));
 }
 
 export default initializeComponent;


### PR DESCRIPTION
Use a more explicit designation for the parameter referencing the component function definition.