### PR TITLE
Clarify focus helper border radius definition

### DIFF
--- a/source/helpers/style-focus.scss
+++ b/source/helpers/style-focus.scss
@@ -11,7 +11,9 @@
     @error "Invalid focus border radius. Check spelling or review helper definition.";
   }
 
-  border-radius: $border-radius;
+  @if $border-radius != null {
+    border-radius: $border-radius;
+  }
   outline: 2px solid $color-brand-100;
   outline-offset: 2px;
 }


### PR DESCRIPTION
It should be made clear that if no border radius token is passed as argument for the focus helper no border radius declaration is provided.