### PR TITLE
Revert focus helper border radius definition clarification

### DIFF
--- a/source/helpers/style-focus.scss
+++ b/source/helpers/style-focus.scss
@@ -11,9 +11,7 @@
     @error "Invalid focus border radius. Check spelling or review helper definition.";
   }
 
-  @if $border-radius != null {
-    border-radius: $border-radius;
-  }
+  border-radius: $border-radius;
   outline: 2px solid $color-brand-100;
   outline-offset: 2px;
 }


### PR DESCRIPTION
This reverts commit ba0b34fc695a28ed0210e6499741ca29ea2ac1fe, reversing
changes made to 0245f6353206643e0cea350a79aaeb759523e51f.

If a property value is `null`, that property is omitted entirely by the Sass compiler.